### PR TITLE
Allow access to raw response

### DIFF
--- a/src/MinFraud/Model/Score.php
+++ b/src/MinFraud/Model/Score.php
@@ -8,6 +8,8 @@ namespace MaxMind\MinFraud\Model;
  *
  * @property integer $creditsRemaining The approximate number of service
  * credits remaining on your account.
+ * @property integer $rawResponse The raw data that comes back from the post
+ * request to the maxmind server.
  * @property string $id This is a UUID that identifies the minFraud request.
  * Please use this ID in bug reports or support requests to MaxMind so that we
  * can easily identify a particular request.
@@ -22,12 +24,17 @@ namespace MaxMind\MinFraud\Model;
  * is highly recommended that you check this array for issues when integrating
  * the web service.
  */
-class Score extends AbstractModel
+class Score extends AbstractModel implements JsonSerializable
 {
     /**
      * @internal
      */
     protected $creditsRemaining;
+
+    /**
+     * @internal
+     */
+    protected $rawResponse;
 
     /**
      * @internal
@@ -46,6 +53,8 @@ class Score extends AbstractModel
 
     public function __construct($response, $locales = ['en'])
     {
+        $this->rawResponse = $response;
+
         $this->creditsRemaining = $this->safeArrayLookup($response['credits_remaining']);
         $this->id = $this->safeArrayLookup($response['id']);
         $this->riskScore = $this->safeArrayLookup($response['risk_score']);
@@ -54,5 +63,9 @@ class Score extends AbstractModel
         foreach ($this->safeArrayLookup($response['warnings'], []) as $warning) {
             array_push($this->warnings, new Warning($warning));
         }
+    }
+
+    public function jsonSerialize() {
+        return $this->rawResponse;
     }
 }


### PR DESCRIPTION
Allowing access to the raw response will allow the data to be easily serialized by json_encode

Fix #9