### PR TITLE
Update README.md to include phar directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Page](http://maxmind.github.io/minfraud-api-php/) under the "API" tab.
 
 ## Usage ##
 
-To use this API, create a new `\Maxmind\MinFraud` object. The constructor
+To use this API, create a new `\MaxMind\MinFraud` object. The constructor
 takes your MaxMind user ID, license key, and an optional options array as
 arguments. This object is immutable. You then build up the request using the
 `->with*` methods as shown below. Each method call returns a new object. The

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You should now have the file `composer.phar` in your project directory.
 Run in your project root:
 
 ```
-php composer.phar require maxmind/minfraud
+php composer.phar require maxmind/minfraud:~1.0
 ```
 
 You should now have the files `composer.json` and `composer.lock` as well as
@@ -38,6 +38,19 @@ from your code:
 
 ```php
 require 'vendor/autoload.php';
+```
+
+## Install via Phar ##
+
+Although we strongly recommend using Composer, we also provide a
+[phar archive](http://php.net/manual/en/book.phar.php) containing all of the
+dependencies for this API. The latest phar archive is available on
+[our releases page](https://github.com/maxmind/minfraud-api-php/releases).
+
+To use the archive, just require it from your script:
+
+```php
+require 'minfraud.phar';
 ```
 
 ## API Documentation ###
@@ -230,6 +243,6 @@ This API uses [Semantic Versioning](http://semver.org/).
 
 ## Copyright and License ##
 
-This software is Copyright (c) 2015 by MaxMind, Inc.
+This software is Copyright (c) 2015-2017 by MaxMind, Inc.
 
 This is free software, licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
* Added directions for using the phar archive
* Updated composer directions to encourage depending on 1.* version
  of the API rather than any version. This will ensure that people
  don't install pre-release version and, if we do a breaking 2.0.0
  release, that isn't pulled in automatically.
* Update the copyright year range.