### PR TITLE
HHVM wording in GeoIP2 PHP API requirements is clarified

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ to the client API, please see
 ## Requirements  ##
 
 This code requires PHP 5.4 or greater. Older versions of PHP are not
-supported. This library works and is tested with HHVM.
+supported. This library is also compatible with HHVM.
 
 There are several other dependencies as defined in the `composer.json` file.
 


### PR DESCRIPTION
PT #157667907; I used the same branch name as the one for GeoIP-PHP. This is under minfraud-api-php. Hopefully it doesn't cause any confusion.