### PR TITLE
Specify HHVM versions for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,11 @@ php:
   - '7.1'
   - '7.2'
   - hhvm
+  - hhvm-nightly
   - nightly
 matrix:
   allow_failures:
+    - php: hhvm-nightly
     - php: nightly
 before_install:
   - composer self-update

--- a/tests/MaxMind/Test/MinFraudTest.php
+++ b/tests/MaxMind/Test/MinFraudTest.php
@@ -979,7 +979,7 @@ class MinFraudTest extends \PHPUnit_Framework_TestCase
 
         $options['httpRequestFactory'] = $factory;
 
-        return new Minfraud(
+        return new MinFraud(
             $userId,
             $licenseKey,
             $options


### PR DESCRIPTION
We are now testing on the two most recent LTS releases and nightly. We allow failures on nightly.