### PR TITLE
Remove hhvm from README and travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,8 @@ matrix:
       env:
         - RUN_LINTER=1
         - RUN_SNYK=1
-    - php: hhvm
-    - php: hhvm-nightly
     - php: nightly
   allow_failures:
-    - php: hhvm-nightly
     - php: nightly
 before_install:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ to the client API, please see
 ## Requirements  ##
 
 This code requires PHP 5.4 or greater. Older versions of PHP are not
-supported. This library is also compatible with HHVM.
+supported.
 
 There are several other dependencies as defined in the `composer.json` file.
 


### PR DESCRIPTION
HHVM 4.0 is released and the version that travis runs, and it [no longer supports php](https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html).