### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "*",
-    "phpunit/phpunit": "4.*",
+    "phpunit/phpunit": "^4.8.36",
     "squizlabs/php_codesniffer": "*"
   },
   "autoload": {

--- a/src/MinFraud.php
+++ b/src/MinFraud.php
@@ -388,9 +388,7 @@ class MinFraud
     private function post($service)
     {
         if (!isset($this->content['device']['ip_address'])) {
-            throw new InvalidInputException(
-                'Key ip_address must be present in device'
-            );
+            throw new InvalidInputException('Key ip_address must be present in device');
         }
         $url = self::$basePath . strtolower($service);
         $class = 'MaxMind\\MinFraud\\Model\\' . $service;
@@ -448,10 +446,7 @@ class MinFraud
         try {
             $validator->check($values);
         } catch (ValidationException $exception) {
-            throw new InvalidInputException(
-                $exception->getMessage(),
-                $exception->getCode()
-            );
+            throw new InvalidInputException($exception->getMessage(), $exception->getCode());
         }
 
         return $values;

--- a/tests/MaxMind/Test/MinFraud/Model/BillingAddressTest.php
+++ b/tests/MaxMind/Test/MinFraud/Model/BillingAddressTest.php
@@ -3,11 +3,12 @@
 namespace MaxMind\Test\MinFraud\Model;
 
 use MaxMind\MinFraud\Model\BillingAddress;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class BillingAddressTest extends \PHPUnit_Framework_TestCase
+class BillingAddressTest extends TestCase
 {
     public function testBillingAddress()
     {

--- a/tests/MaxMind/Test/MinFraud/Model/CreditCardTest.php
+++ b/tests/MaxMind/Test/MinFraud/Model/CreditCardTest.php
@@ -3,11 +3,12 @@
 namespace MaxMind\Test\MinFraud\Model;
 
 use MaxMind\MinFraud\Model\CreditCard;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class CreditCardTest extends \PHPUnit_Framework_TestCase
+class CreditCardTest extends TestCase
 {
     public function testCreditCard()
     {

--- a/tests/MaxMind/Test/MinFraud/Model/DeviceTest.php
+++ b/tests/MaxMind/Test/MinFraud/Model/DeviceTest.php
@@ -3,11 +3,12 @@
 namespace MaxMind\Test\MinFraud\Model;
 
 use MaxMind\MinFraud\Model\Device;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class DeviceTest extends \PHPUnit_Framework_TestCase
+class DeviceTest extends TestCase
 {
     public function testDevice()
     {

--- a/tests/MaxMind/Test/MinFraud/Model/DispositionTest.php
+++ b/tests/MaxMind/Test/MinFraud/Model/DispositionTest.php
@@ -3,11 +3,12 @@
 namespace MaxMind\Test\MinFraud\Model;
 
 use MaxMind\MinFraud\Model\Disposition;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class DispositionTest extends \PHPUnit_Framework_TestCase
+class DispositionTest extends TestCase
 {
     public function testDisposition()
     {

--- a/tests/MaxMind/Test/MinFraud/Model/EmailTest.php
+++ b/tests/MaxMind/Test/MinFraud/Model/EmailTest.php
@@ -3,11 +3,12 @@
 namespace MaxMind\Test\MinFraud\Model;
 
 use MaxMind\MinFraud\Model\Email;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class EmailTest extends \PHPUnit_Framework_TestCase
+class EmailTest extends TestCase
 {
     public function testEmail()
     {

--- a/tests/MaxMind/Test/MinFraud/Model/IpLocationTest.php
+++ b/tests/MaxMind/Test/MinFraud/Model/IpLocationTest.php
@@ -3,11 +3,12 @@
 namespace MaxMind\Test\MinFraud\Model;
 
 use MaxMind\MinFraud\Model\IpAddress;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class IpLocationTest extends \PHPUnit_Framework_TestCase
+class IpLocationTest extends TestCase
 {
     public function testIpAddress()
     {

--- a/tests/MaxMind/Test/MinFraud/Model/IssuerTest.php
+++ b/tests/MaxMind/Test/MinFraud/Model/IssuerTest.php
@@ -3,11 +3,12 @@
 namespace MaxMind\Test\MinFraud\Model;
 
 use MaxMind\MinFraud\Model\Issuer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class IssuerTest extends \PHPUnit_Framework_TestCase
+class IssuerTest extends TestCase
 {
     public function testIssuer()
     {

--- a/tests/MaxMind/Test/MinFraud/Model/ScoreTest.php
+++ b/tests/MaxMind/Test/MinFraud/Model/ScoreTest.php
@@ -4,11 +4,12 @@ namespace MaxMind\Test\MinFraud\Model;
 
 use MaxMind\MinFraud\Model\Score;
 use MaxMind\Test\MinFraudData as Data;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class ScoreTest extends \PHPUnit_Framework_TestCase
+class ScoreTest extends TestCase
 {
     protected function response()
     {

--- a/tests/MaxMind/Test/MinFraud/Model/ShippingAddressTest.php
+++ b/tests/MaxMind/Test/MinFraud/Model/ShippingAddressTest.php
@@ -3,11 +3,12 @@
 namespace MaxMind\Test\MinFraud\Model;
 
 use MaxMind\MinFraud\Model\ShippingAddress;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class ShippingAddressTest extends \PHPUnit_Framework_TestCase
+class ShippingAddressTest extends TestCase
 {
     public function testShippingAddress()
     {

--- a/tests/MaxMind/Test/MinFraud/Model/WarningTest.php
+++ b/tests/MaxMind/Test/MinFraud/Model/WarningTest.php
@@ -3,11 +3,12 @@
 namespace MaxMind\Test\MinFraud\Model;
 
 use MaxMind\MinFraud\Model\Warning;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class WarningTest extends \PHPUnit_Framework_TestCase
+class WarningTest extends TestCase
 {
     public function testWarning()
     {

--- a/tests/MaxMind/Test/MinFraud/Validation/Rules/EventTest.php
+++ b/tests/MaxMind/Test/MinFraud/Validation/Rules/EventTest.php
@@ -3,33 +3,40 @@
 namespace MaxMind\Test;
 
 use MaxMind\MinFraud\Validation\Rules\Event;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class EventTest extends \PHPUnit_Framework_TestCase
+class EventTest extends TestCase
 {
-    public function testEventType()
+    /**
+     * @dataProvider eventTypeDataProvider
+     *
+     * @param mixed $good
+     */
+    public function testEventType($good)
     {
         $validator = new Event();
 
-        $good = [
-            'account_creation',
-            'account_login',
-            'email_change',
-            'password_reset',
-            'payout_change',
-            'purchase',
-            'recurring_purchase',
-            'referral',
-            'survey',
-        ];
+        $this->assertTrue(
+            $validator->check(['type' => $good]),
+            $good
+        );
+    }
 
-        foreach ($good as $value) {
-            $this->assertTrue(
-                $validator->check(['type' => $value]),
-                $value
-            );
-        }
+    public function eventTypeDataProvider()
+    {
+        return [
+            ['account_creation'],
+            ['account_login'],
+            ['email_change'],
+            ['password_reset'],
+            ['payout_change'],
+            ['purchase'],
+            ['recurring_purchase'],
+            ['referral'],
+            ['survey'],
+        ];
     }
 }

--- a/tests/MaxMind/Test/MinFraudTest.php
+++ b/tests/MaxMind/Test/MinFraudTest.php
@@ -6,11 +6,12 @@ use Composer\CaBundle\CaBundle;
 use MaxMind\MinFraud;
 use MaxMind\Test\MinFraudData as Data;
 use MaxMind\WebService\Client;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class MinFraudTest extends \PHPUnit_Framework_TestCase
+class MinFraudTest extends TestCase
 {
     /**
      * @dataProvider services


### PR DESCRIPTION
# Changed log
- Using the `assertTrue` and `assertFalse` to assert the expected values are same as `true` or `false`.
- To support future `PHPUnit` version easily, upgrading to the latest `PHPUnit 4.x` version.
And using the `PHPUnit` class namespace.
- Fix the coding style via `php-cs-fixer`.