### PR TITLE
Add support for 8 digit IINs and 2 digit last_digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,16 @@ CHANGELOG
   `last_digits`/`last_4_digits` also now supports two digit values in
   addition to the previous four digit values.
 * Eight digit `/credit_card/issuer_id_number` inputs are now supported in
-  addition to the previously accepted six digit `issuer_id_number`. If you
-  send six digits for the `issuer_id_number`, you should send the last four
-  digits for `last_digits`. If you send eight digits for `issuer_id_number`
-  you should send the last two digits for `last_digits`.
+  addition to the previously accepted six digit `issuer_id_number`. In most
+  cases, you should send the last four digits for `last_digits`. If you send
+  an `issuer_id_number` that contains an eight digit IIN, and if the credit
+  card brand is not one of the following, you should send the last two digits
+  for `last_digits`:
+  * `Discover`
+  * `JCB`
+  * `Mastercard`
+  * `UnionPay`
+  * `Visa`
 
 1.19.0 (2021-08-25)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ CHANGELOG
 * The return type on `\MaxMind\MinFraud\Model\AbstractModel::jsonSerialize` has
   been removed so that it does not to conflict with
   `JsonSerializable::jsonSerialize` on PHP 8+.
+* The `/credit_card/last_4_digits` input has been deprecated in favor of
+  `/credit_card/last_digits` and will be removed in a future release.
+  `last_digits`/`last_4_digits` also now supports two digit values in
+  addition to the previous four digit values.
+* Eight digit `/credit_card/issuer_id_number` inputs are now supported in
+  addition to the previously accepted six digit `issuer_id_number`. If you
+  send six digits for the `issuer_id_number`, you should send the last four
+  digits for `last_digits`. If you send eight digits for `issuer_id_number`
+  you should send the last two digits for `last_digits`.
 
 1.19.0 (2021-08-25)
 -------------------

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ $request = $mf->withDevice([
     'decline_code'          => 'invalid number',
 ])->withCreditCard([
     'issuer_id_number'         => '411111',
-    'last_4_digits'            => '7643',
+    'last_digits'              => '7643',
     'bank_name'                => 'Bank of No Hope',
     'bank_phone_country_code'  => '1',
     'bank_phone_number'        => '123-456-1234',

--- a/src/MinFraud.php
+++ b/src/MinFraud.php
@@ -240,6 +240,8 @@ class MinFraud extends MinFraud\ServiceClient
      */
     public function withCreditCard(array $values): self
     {
+        $values = Util::cleanCreditCard($values);
+
         return $this->validateAndAdd('CreditCard', 'credit_card', $values);
     }
 

--- a/src/MinFraud/Util.php
+++ b/src/MinFraud/Util.php
@@ -86,4 +86,15 @@ class Util
 
         return md5("$localPart@$domain");
     }
+
+    public static function cleanCreditCard(array $values): array
+    {
+        if (isset($values['last_4_digits'])) {
+            @trigger_error('last_4_digits has been deprecated in favor of last_digits', \E_USER_DEPRECATED);
+            $values['last_digits'] = $values['last_4_digits'];
+            unset($values['last_4_digits']);
+        }
+
+        return $values;
+    }
 }

--- a/src/MinFraud/Validation/Rules/CreditCard.php
+++ b/src/MinFraud/Validation/Rules/CreditCard.php
@@ -15,23 +15,16 @@ class CreditCard extends AbstractWrapper
     public function __construct()
     {
         parent::__construct(
-            v::allOf(
-                v::when(
-                    v::key('issuer_id_number', v::regex('/^[0-9]{8}$/'), true),
-                    v::key('last_digits', v::regex('/^[0-9]{2}$/'), false),
-                    v::key('last_digits', v::regex('/^(?:[0-9]{2}|[0-9]{4})$/'), false),
-                ),
-                v::keySet(
-                    v::key('avs_result', v::stringType()->length(1, 1), false),
-                    v::key('bank_name', v::stringType(), false),
-                    v::key('bank_phone_country_code', new TelephoneCountryCode(), false),
-                    v::key('bank_phone_number', v::stringType(), false),
-                    v::key('cvv_result', v::stringType()->length(1, 1), false),
-                    v::key('issuer_id_number', v::regex('/^(?:[0-9]{6}|[0-9]{8})$/'), false),
-                    v::key('last_digits', null, false), // already validated
-                    v::key('token', v::regex('/^[\x21-\x7E]{1,255}$/')->not(v::regex('/^[0-9]{1,19}$/')), false),
-                    v::key('was_3d_secure_successful', v::boolVal(), false),
-                )
+            v::keySet(
+                v::key('avs_result', v::stringType()->length(1, 1), false),
+                v::key('bank_name', v::stringType(), false),
+                v::key('bank_phone_country_code', new TelephoneCountryCode(), false),
+                v::key('bank_phone_number', v::stringType(), false),
+                v::key('cvv_result', v::stringType()->length(1, 1), false),
+                v::key('issuer_id_number', v::regex('/^(?:[0-9]{6}|[0-9]{8})$/'), false),
+                v::key('last_digits', v::regex('/^(?:[0-9]{2}|[0-9]{4})$/'), false),
+                v::key('token', v::regex('/^[\x21-\x7E]{1,255}$/')->not(v::regex('/^[0-9]{1,19}$/')), false),
+                v::key('was_3d_secure_successful', v::boolVal(), false),
             )
         );
     }

--- a/src/MinFraud/Validation/Rules/CreditCard.php
+++ b/src/MinFraud/Validation/Rules/CreditCard.php
@@ -14,16 +14,25 @@ class CreditCard extends AbstractWrapper
 {
     public function __construct()
     {
-        parent::__construct(v::keySet(
-            v::key('avs_result', v::stringType()->length(1, 1), false),
-            v::key('bank_name', v::stringType(), false),
-            v::key('bank_phone_country_code', new TelephoneCountryCode(), false),
-            v::key('bank_phone_number', v::stringType(), false),
-            v::key('cvv_result', v::stringType()->length(1, 1), false),
-            v::key('issuer_id_number', v::regex('/^[0-9]{6}$/'), false),
-            v::key('last_4_digits', v::regex('/^[0-9]{4}$/'), false),
-            v::key('token', v::regex('/^[\x21-\x7E]{1,255}$/')->not(v::regex('/^[0-9]{1,19}$/')), false),
-            v::key('was_3d_secure_successful', v::boolVal(), false),
-        ));
+        parent::__construct(
+            v::allOf(
+                v::when(
+                    v::key('issuer_id_number', v::regex('/^[0-9]{8}$/'), true),
+                    v::key('last_digits', v::regex('/^[0-9]{2}$/'), false),
+                    v::key('last_digits', v::regex('/^(?:[0-9]{2}|[0-9]{4})$/'), false),
+                ),
+                v::keySet(
+                    v::key('avs_result', v::stringType()->length(1, 1), false),
+                    v::key('bank_name', v::stringType(), false),
+                    v::key('bank_phone_country_code', new TelephoneCountryCode(), false),
+                    v::key('bank_phone_number', v::stringType(), false),
+                    v::key('cvv_result', v::stringType()->length(1, 1), false),
+                    v::key('issuer_id_number', v::regex('/^(?:[0-9]{6}|[0-9]{8})$/'), false),
+                    v::key('last_digits', null, false), // already validated
+                    v::key('token', v::regex('/^[\x21-\x7E]{1,255}$/')->not(v::regex('/^[0-9]{1,19}$/')), false),
+                    v::key('was_3d_secure_successful', v::boolVal(), false),
+                )
+            )
+        );
     }
 }

--- a/tests/MaxMind/Test/MinFraudTest.php
+++ b/tests/MaxMind/Test/MinFraudTest.php
@@ -473,9 +473,6 @@ class MinFraudTest extends \MaxMind\Test\MinFraud\ServiceClientTest
 
     public function testCreditCard8DigitIIN4DigitLastDigits(): void
     {
-        $this->expectException(InvalidInputException::class);
-        $this->expectExceptionMessage('must validate against');
-
         $this->createMinFraudRequestWithFullResponse(
             'insights',
             0

--- a/tests/MaxMind/Test/MinFraudTest.php
+++ b/tests/MaxMind/Test/MinFraudTest.php
@@ -449,9 +449,9 @@ class MinFraudTest extends \MaxMind\Test\MinFraud\ServiceClientTest
     }
 
     /**
-     * @dataProvider badLast4Digits
+     * @dataProvider badLastDigits
      */
-    public function testCreditCardWithBadLast4(string $last4): void
+    public function testCreditCardWithBadLastDigits(string $lastDigits): void
     {
         $this->expectException(InvalidInputException::class);
         $this->expectExceptionMessage('must validate against');
@@ -459,16 +459,35 @@ class MinFraudTest extends \MaxMind\Test\MinFraud\ServiceClientTest
         $this->createMinFraudRequestWithFullResponse(
             'insights',
             0
-        )->withCreditCard(['last_4_digits' => $last4]);
+        )->withCreditCard(['last_digits' => $lastDigits]);
     }
 
-    public function badLast4Digits(): array
+    public function badLastDigits(): array
     {
         return [
             ['12345'],
             ['123'],
             ['a234'],
         ];
+    }
+
+    public function testCreditCard8DigitIIN4DigitLastDigits(): void
+    {
+        $this->expectException(InvalidInputException::class);
+        $this->expectExceptionMessage('must validate against');
+
+        $this->createMinFraudRequestWithFullResponse(
+            'insights',
+            0
+        )->withCreditCard(['issuer_id_number' => '88888888', 'last_digits' => '1234']);
+    }
+
+    public function testCreditCardDeprecatedLast4Digits(): void
+    {
+        $this->createMinFraudRequestWithFullResponse(
+            'insights',
+            0
+        )->withCreditCard(['issuer_id_number' => '666666', 'last_4_digits' => '1234']);
     }
 
     /**

--- a/tests/data/minfraud/full-request.json
+++ b/tests/data/minfraud/full-request.json
@@ -47,7 +47,7 @@
   },
   "credit_card": {
     "issuer_id_number": "411111",
-    "last_4_digits": "7643",
+    "last_digits": "7643",
     "bank_name": "Bank of No Hope",
     "bank_phone_country_code": "1",
     "bank_phone_number": "123-456-1234",


### PR DESCRIPTION
Previously issuer_id_number was expected to be 6 digits and
last_4_digits to be 4 digits. This changes the validation to
additionally allow for 8 digit issuer_id_numbers and 2 digit
last_4_digits.

Additionally last_4_digits has been deprecated in favor of the
more appropriately named last_digits.