### PR TITLE
Revert PR #130

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,6 @@ CHANGELOG
   * `payvision`
   * `trustly`
   * `windcave`
-* The return type on `\MaxMind\MinFraud\Model\AbstractModel::jsonSerialize` has
-  been removed so that it does not to conflict with
-  `JsonSerializable::jsonSerialize` on PHP 8+.
 * The `/credit_card/last_4_digits` input has been deprecated in favor of
   `/credit_card/last_digits` and will be removed in a future release.
   `last_digits`/`last_4_digits` also now supports two digit values in

--- a/src/MinFraud/Model/AbstractModel.php
+++ b/src/MinFraud/Model/AbstractModel.php
@@ -68,12 +68,9 @@ abstract class AbstractModel implements \JsonSerializable
     }
 
     /**
-     * @return mixed data that can be serialized by json_encode
+     * @return array data that can be serialized by json_encode
      */
-    // We don't specify a return type here as PHP 8 has "mixed" as the return
-    // type for "JsonSerializable::jsonSerialize", but PHP 7 doesn't support
-    // "mixed".
-    public function jsonSerialize()
+    public function jsonSerialize(): ?array
     {
         // @phpstan-ignore-next-line
         return $this->rawResponse;


### PR DESCRIPTION
Covariant return types are allowed and are not deprecated.
