### PR TITLE
1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-1.21.0
+1.21.0 (2022-03-28)
 -------------------
 
 * Added the input `/credit_card/country`. This is the country where the issuer

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": ">=7.3",
     "ext-json": "*",
     "geoip2/geoip2": "^2.12",
-    "maxmind/web-service-common": "^0.8.1",
+    "maxmind/web-service-common": "^0.9.0",
     "respect/validation": "~2.1"
   },
   "require-dev": {

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -93,7 +93,13 @@ if [ -n "$(git status --porcelain)" ]; then
 fi
 
 # Using Composer is possible, but they don't recommend it.
-wget -O phpDocumentor.phar https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.3.0/phpDocumentor.phar
+phpdocumentor_phar_hash='4a93d278fd4581f17760903134d85fcde3d40d93f739c8c648f3ed02c9c3e7bb  phpDocumentor.phar'
+
+if ! echo "$phpdocumentor_phar_hash" | sha256sum -c; then
+    wget -O phpDocumentor.phar https://github.com/phpDocumentor/phpDocumentor/releases/download/v3.3.1/phpDocumentor.phar
+fi
+
+echo "$phpdocumentor_phar_hash" | sha256sum -c
 
 # Use cache dir in /tmp as otherwise cache files get into the output directory.
 cachedir="/tmp/phpdoc-$$-$RANDOM"

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -46,9 +46,13 @@ php composer.phar update --no-dev
 
 perl -pi -e "s/(?<=const VERSION = ').+?(?=';)/$tag/g" src/MinFraud/ServiceClient.php
 
-if [ ! -f box.phar ]; then
-    wget -O box.phar "https://github.com/box-project/box/releases/download/3.14.0/box.phar"
+box_phar_hash='f508e28f309d7e95a319bdcd5f13dcfbb18eb91cb7a6cac9b69bc7799d78bdf9 box.phar'
+
+if ! echo "$box_phar_hash" | sha256sum -c; then
+    wget -O box.phar "https://github.com/box-project/box/releases/download/3.16.0/box.phar"
 fi
+
+echo "$box_phar_hash" | sha256sum -c
 
 php box.phar compile
 

--- a/src/MinFraud/ServiceClient.php
+++ b/src/MinFraud/ServiceClient.php
@@ -10,7 +10,7 @@ use Respect\Validation\Exceptions\ValidationException;
 
 abstract class ServiceClient
 {
-    public const VERSION = 'v1.20.0';
+    public const VERSION = 'v1.21.0';
 
     /**
      * @var Client


### PR DESCRIPTION
- Update web-service-common
- Set release date
- Bump box version and add a hash check
- Update phpDocumentor and add a hash check
- Update for v1.21.0
