### PR TITLE
Easier way to extend MinFraud object and clean linked tests

### DIFF
--- a/src/MinFraud.php
+++ b/src/MinFraud.php
@@ -44,7 +44,7 @@ class MinFraud extends MinFraud\ServiceClient
     /**
      * @var array<string, mixed>
      */
-    private array $content;
+    protected array $content;
 
     private bool $hashEmail;
 

--- a/tests/MaxMind/Test/MinFraudTest.php
+++ b/tests/MaxMind/Test/MinFraudTest.php
@@ -195,7 +195,6 @@ class MinFraudTest extends ServiceClientTester
         // Reflection isn't ideal, but this is the easiest way to check.
         $class = new \ReflectionClass(MinFraud::class);
         $prop = $class->getProperty('content');
-        $prop->setAccessible(true);
 
         $client = $this->createMinFraudRequestWithFullResponse(
             'insights',
@@ -234,7 +233,6 @@ class MinFraudTest extends ServiceClientTester
         // Reflection isn't ideal, but this is the easiest way to check.
         $class = new \ReflectionClass(MinFraud::class);
         $prop = $class->getProperty('content');
-        $prop->setAccessible(true);
 
         $client = $this->createMinFraudRequestWithFullResponse(
             'insights',


### PR DESCRIPTION
**Description**

- I think we should have the ability in our project to extend from the `MinFraud` object if we want to rewrite some logic about it
   - Imagine the logic need to interact with the `$content` property : we could try to deal with `ReflectionClass` but it's not really clean and it make the code non-testable if we mock it (this will reflect a mock, too complex logic)
  - &rarr; So I suggest to make this property `protected` instead of `private`

- Second thing
  - &rarr; I've removed the `setAccessible()` method as not useful from PHP 8.1 (it coincide with this package requirement)