### PR TITLE
MinFraud now implements JsonSerializable

### DIFF
--- a/src/MinFraud.php
+++ b/src/MinFraud.php
@@ -39,7 +39,7 @@ use MaxMind\MinFraud\Util;
  *
  * If the request fails, an exception is thrown.
  */
-class MinFraud extends MinFraud\ServiceClient
+class MinFraud extends MinFraud\ServiceClient implements \JsonSerializable
 {
     /**
      * @var array<string, mixed>
@@ -96,6 +96,18 @@ class MinFraud extends MinFraud\ServiceClient
         }
 
         parent::__construct($accountId, $licenseKey, $options);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'content' => $this->content ?? [],
+            'hashEmail' => $this->hashEmail,
+            'locales' => $this->locales,
+        ];
     }
 
     /**

--- a/tests/MaxMind/Test/MinFraudTest.php
+++ b/tests/MaxMind/Test/MinFraudTest.php
@@ -16,6 +16,24 @@ use MaxMind\Test\MinFraudData as Data;
  */
 class MinFraudTest extends ServiceClientTester
 {
+    public function testMinFraud(): void
+    {
+        $minFraud = new MinFraud(0, '', ['hashEmail' => true, 'locales' => ['en', 'fr']]);
+        $minFraud = $minFraud->withDevice(['ip_address' => '1.2.3.4']);
+
+        $array = [
+            'content' => ['device' => ['ip_address' => '1.2.3.4']],
+            'hashEmail' => true,
+            'locales' => ['en', 'fr'],
+        ];
+
+        $this->assertSame(
+            $array,
+            $minFraud->jsonSerialize(),
+            'correctly implements JsonSerializable'
+        );
+    }
+
     /**
      * @dataProvider services
      */

--- a/tests/MaxMind/Test/MinFraudTest.php
+++ b/tests/MaxMind/Test/MinFraudTest.php
@@ -213,7 +213,6 @@ class MinFraudTest extends ServiceClientTester
         // Reflection isn't ideal, but this is the easiest way to check.
         $class = new \ReflectionClass(MinFraud::class);
         $prop = $class->getProperty('content');
-        $prop->setAccessible(true);
 
         $client = $this->createMinFraudRequestWithFullResponse(
             'insights',
@@ -252,7 +251,6 @@ class MinFraudTest extends ServiceClientTester
         // Reflection isn't ideal, but this is the easiest way to check.
         $class = new \ReflectionClass(MinFraud::class);
         $prop = $class->getProperty('content');
-        $prop->setAccessible(true);
 
         $client = $this->createMinFraudRequestWithFullResponse(
             'insights',


### PR DESCRIPTION
**Description**

The `MinFraud` object now implements `JsonSerializable` interface for convenient use.

Another thing :
  - &rarr; I've removed the `setAccessible()` method as not useful from PHP 8.1 (it coincide with this package requirement)

---

Following of this PR : https://github.com/maxmind/minfraud-api-php/pull/192