### PR TITLE
Add `clear` to the valid tag values (STF-190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ CHANGELOG
   [Device Tracking Add-on](https://dev.maxmind.com/minfraud/track-devices)
   for explicit device linking.
 * Added `fat_zebra` to the payment processor validation.
+* Added `clear` to the valid values for the `tag` parameter on the Report
+  Transaction API.
 
 3.6.0 (2026-01-20)
 ------------------

--- a/src/MinFraud/ReportTransaction.php
+++ b/src/MinFraud/ReportTransaction.php
@@ -53,8 +53,8 @@ class ReportTransaction extends ServiceClient
      *                                             `maxmindId`, `minfraudId`, or `transactionId`.
      * @param string               $tag            Required. A string indicating the likelihood that a
      *                                             transaction may be fraudulent. Possible values:
-     *                                             not_fraud, suspected_fraud, spam_or_abuse, or
-     *                                             chargeback.
+     *                                             not_fraud, suspected_fraud, spam_or_abuse,
+     *                                             chargeback, or clear.
      * @param string               $chargebackCode Optional. A string which is provided by your payment
      *                                             processor indicating the reason for the chargeback.
      * @param string               $maxmindId      Optional. A unique eight character string identifying
@@ -159,9 +159,9 @@ class ReportTransaction extends ServiceClient
             // This is required so we always throw an exception if it is not set
             throw new InvalidInputException('A tag is required');
         }
-        if (!\in_array($tag, ['not_fraud', 'suspected_fraud', 'spam_or_abuse', 'chargeback'], true)) {
+        if (!\in_array($tag, ['not_fraud', 'suspected_fraud', 'spam_or_abuse', 'chargeback', 'clear'], true)) {
             $this->maybeThrowInvalidInputException(
-                "$tag must be one of 'not_fraud', 'suspected_fraud', 'spam_or_abuse', or 'chargeback'",
+                "$tag must be one of 'not_fraud', 'suspected_fraud', 'spam_or_abuse', 'chargeback', or 'clear'",
             );
         }
         $values['tag'] = $tag;

--- a/tests/MaxMind/Test/MinFraud/ReportTransaction/ReportTransactionTest.php
+++ b/tests/MaxMind/Test/MinFraud/ReportTransaction/ReportTransactionTest.php
@@ -59,6 +59,12 @@ class ReportTransactionTest extends ServiceClientTester
         $this->createReportTransactionRequest($req, 1)->report($req);
 
         $req = [
+            'ip_address' => '1.1.1.1',
+            'tag' => 'clear',
+        ];
+        $this->createReportTransactionRequest($req, 1)->report($req);
+
+        $req = [
             'maxmind_id' => '12345678',
             'tag' => 'not_fraud',
         ];


### PR DESCRIPTION
## Summary

- Adds `'clear'` to the `in_array` validation list in
  `ReportTransaction::report()`, updates the matching error message,
  and extends the `@param $tag` PHPDoc.
- Adds a new case to `testRequiredFields` covering `tag => 'clear'`.
- Appends a bullet to the existing unreleased `3.7.0` entry in
  `CHANGELOG.md`.

The `clear` tag retracts a previously reported fraud report on a transaction
(restoring its label to "unknown", distinct from the positive `not_fraud`
signal). Backend support shipped in STF-15; this adds SDK support per STF-190.

Linear: https://linear.app/maxmind/issue/STF-190

## Test plan

- [ ] `vendor/bin/phpunit tests/MaxMind/Test/MinFraud/ReportTransaction/ReportTransactionTest.php`
      (relying on CI)
- [x] Change is straightforward: one value added to the allow-list and the
      corresponding error string / PHPDoc text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)