### PR TITLE
Use 'GeoIP'/'GeoLite' branding in documentation

### DIFF
--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -129,10 +129,10 @@ else
 fi
 
 if [ ! -d .geoip2 ]; then
-    echo "Cloning GeoIP2 for docs"
+    echo "Cloning GeoIP for docs"
     git clone git@github.com:maxmind/GeoIP2-php.git .geoip2
 else
-    echo "Updating GeoIP2 for docs"
+    echo "Updating GeoIP for docs"
     pushd .geoip2
     git pull
     popd

--- a/src/MinFraud/Model/GeoIp2Location.php
+++ b/src/MinFraud/Model/GeoIp2Location.php
@@ -7,7 +7,7 @@ namespace MaxMind\MinFraud\Model;
 use GeoIp2\Record\Location;
 
 /**
- * Model of the GeoIP2 Location information, including the local time.
+ * Model of the GeoIP Location information, including the local time.
  */
 class GeoIp2Location extends Location
 {

--- a/src/MinFraud/Model/Insights.php
+++ b/src/MinFraud/Model/Insights.php
@@ -60,7 +60,7 @@ class Insights implements \JsonSerializable
     public readonly string $id;
 
     /**
-     * @var IpAddress an object containing GeoIP2 and minFraud Insights
+     * @var IpAddress an object containing GeoIP and minFraud Insights
      *                information about the geolocated IP address
      */
     public readonly IpAddress $ipAddress;

--- a/src/MinFraud/Model/IpAddress.php
+++ b/src/MinFraud/Model/IpAddress.php
@@ -15,7 +15,7 @@ use GeoIp2\Record\Subdivision;
 use GeoIp2\Record\Traits;
 
 /**
- * Model containing GeoIP2 data and the risk for the IP address.
+ * Model containing GeoIP data and the risk for the IP address.
  */
 class IpAddress implements \JsonSerializable
 {

--- a/tests/MaxMind/Test/MinFraudTest.php
+++ b/tests/MaxMind/Test/MinFraudTest.php
@@ -207,7 +207,7 @@ class MinFraudTest extends ServiceClientTester
         $this->assertSame(
             'Royaume-Uni',
             $insights->ipAddress->country->name,
-            'locales setting made it to the GeoIP2 models'
+            'locales setting made it to the GeoIP models'
         );
     }
 


### PR DESCRIPTION
Updates prose/documentation to refer to the products as "GeoIP"/"GeoLite" instead of "GeoIP2"/"GeoLite2". Technical identifiers (packages, class names, .mmdb filenames, edition IDs, the geolite.info hostname, URLs) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)