### PR TITLE
Expand email alias domain lists

### DIFF
--- a/src/MinFraud/Util.php
+++ b/src/MinFraud/Util.php
@@ -127,6 +127,7 @@ class Util
         'fastemailer.com' => true,
         'fastest.cc' => true,
         'fastimap.com' => true,
+        'fastmail.ca' => true,
         'fastmail.cn' => true,
         'fastmail.co.uk' => true,
         'fastmail.com' => true,
@@ -223,6 +224,7 @@ class Util
      * @var array<string, bool>
      */
     private static $yahooDomains = [
+        'myyahoo.com' => true,
         'y7mail.com' => true,
         'yahoo.at' => true,
         'yahoo.be' => true,

--- a/tests/MaxMind/Test/MinFraud/UtilTest.php
+++ b/tests/MaxMind/Test/MinFraud/UtilTest.php
@@ -189,6 +189,16 @@ class UtilTest extends TestCase
                 ],
             ],
             [
+                'name' => 'Fastmail Canada alias domain',
+                'input' => ['email' => ['address' => 'alias@user.fastmail.ca']],
+                'expected' => [
+                    'email' => [
+                        'address' => md5('user@fastmail.ca'),
+                        'domain' => 'user.fastmail.ca',
+                    ],
+                ],
+            ],
+            [
                 'name' => 'Domain with multiple host parts',
                 'input' => ['email' => ['address' => 'foo@bar.example.com']],
                 'expected' => [
@@ -205,6 +215,16 @@ class UtilTest extends TestCase
                     'email' => [
                         'address' => md5('foo@ymail.com'),
                         'domain' => 'ymail.com',
+                    ],
+                ],
+            ],
+            [
+                'name' => 'Alternate Yahoo signup domain',
+                'input' => ['email' => ['address' => 'test-alias@myyahoo.com']],
+                'expected' => [
+                    'email' => [
+                        'address' => md5('test@myyahoo.com'),
+                        'domain' => 'myyahoo.com',
                     ],
                 ],
             ],


### PR DESCRIPTION
## Summary

Adds two newly identified alias domains so more equivalent addresses
normalize to the same value before hashing:

- `fastmail.ca` — Fastmail's own Canadian domain. Confirmed via MX
  records resolving to Fastmail's `messagingengine.com` infrastructure,
  and listed on Fastmail's official domain list.
- `myyahoo.com` — an alternate Yahoo-owned signup domain (WHOIS
  registrant: Yahoo Assets LLC), functionally identical to yahoo.com.

Both run on their provider's own native mail platform with no
third-party migration history, so the existing normalization logic
applies to them exactly as it does to their canonical counterparts.

This mirrors the same addition made to the minFraud web service's own
email normalization.

## Testing

Added matching unit test cases following the existing pattern. Not run
locally — no PHP/Composer available in this environment — so CI
should be checked before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email normalization for Fastmail Canada and alternate Yahoo addresses.
  * Ensured aliases using these domains are consistently processed and hashed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->